### PR TITLE
SymbolRow design improvements

### DIFF
--- a/data/ui/SymbolRow.ui
+++ b/data/ui/SymbolRow.ui
@@ -41,7 +41,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
                 <property name="margin_bottom">5</property>
-                <property name="label"></property>
+                <property name="label">__title__</property>
                 <property name="single_line_mode">True</property>
                 <style>
                   <class name="text-md"/>
@@ -64,7 +64,8 @@
                     <property name="can_focus">False</property>
                     <property name="valign">end</property>
                     <property name="margin_bottom">3</property>
-                    <property name="label"></property>
+                    <property name="label">__change__</property>
+                    <attributes>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -78,7 +79,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="valign">end</property>
-                    <property name="label"></property>
+                    <property name="label">__price__</property>
                     <property name="single_line_mode">True</property>
                     <style>
                       <class name="text-lg"/>
@@ -98,7 +99,7 @@
                     <property name="valign">end</property>
                     <property name="margin_start">5</property>
                     <property name="margin_bottom">3</property>
-                    <property name="label"></property>
+                    <property name="label">__currency__</property>
                     <style>
                       <class name="text-bold"/>
                     </style>
@@ -126,6 +127,7 @@
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin_top">5</property>
+                    <property name="label" translatable="yes">__market__</property>
                     <style>
                       <class name="text-sm"/>
                     </style>
@@ -152,6 +154,7 @@
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin_top">5</property>
+                    <property name="label" translatable="yes">__time__</property>
                     <style>
                       <class name="dim-label"/>
                       <class name="text-sm"/>

--- a/data/ui/SymbolRow.ui
+++ b/data/ui/SymbolRow.ui
@@ -78,7 +78,6 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="valign">end</property>
-                    <property name="xpad">0</property>
                     <property name="label"></property>
                     <property name="single_line_mode">True</property>
                     <style>

--- a/data/ui/SymbolRow.ui
+++ b/data/ui/SymbolRow.ui
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
-  <requires lib="libhandy" version="0.0"/>
   <template class="MarketsSymbolRow" parent="GtkListBoxRow">
     <property name="width_request">100</property>
     <property name="height_request">50</property>
@@ -17,13 +16,15 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="receives_default">False</property>
-            <property name="draw_indicator">True</property>
             <property name="margin_start">10</property>
             <property name="margin_end">5</property>
+            <property name="draw_indicator">True</property>
             <signal name="toggled" handler="on_checkbox_toggled" swapped="no"/>
           </object>
           <packing>
+            <property name="expand">False</property>
             <property name="fill">True</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
@@ -66,6 +67,8 @@
                     <property name="margin_bottom">3</property>
                     <property name="label">__change__</property>
                     <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -132,6 +135,11 @@
                       <class name="text-sm"/>
                     </style>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel">
@@ -140,13 +148,16 @@
                     <property name="halign">start</property>
                     <property name="margin_top">5</property>
                     <property name="label"> · </property>
-                    <attributes>
-                    </attributes>
                     <style>
                       <class name="dim-label"/>
                       <class name="text-sm"/>
                     </style>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="time">
@@ -160,6 +171,29 @@
                       <class name="text-sm"/>
                     </style>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="percent_change">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="valign">end</property>
+                    <property name="margin_bottom">3</property>
+                    <property name="label">__percent_change__</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="pack_type">end</property>
+                    <property name="position">3</property>
+                  </packing>
                 </child>
               </object>
               <packing>
@@ -172,6 +206,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>

--- a/src/SymbolRow.vala
+++ b/src/SymbolRow.vala
@@ -8,6 +8,9 @@ public class Markets.SymbolRow : Gtk.ListBoxRow {
     private Gtk.Label change;
 
     [GtkChild]
+    private Gtk.Label percent_change;
+
+    [GtkChild]
     private Gtk.Label price;
 
     [GtkChild]
@@ -51,18 +54,29 @@ public class Markets.SymbolRow : Gtk.ListBoxRow {
         this.currency.label = s.currency.up ();
 
         this.change.label =
-            @"%'+.$(s.precision)F (%'+.2F%)".printf (
-                s.regular_market_change,
+            @"%'+.$(s.precision)F".printf (
+                s.regular_market_change
+            );
+
+        this.percent_change.label =
+            @"(%'+.2F%)".printf (
                 s.regular_market_change_percent
             );
 
         var change_style = this.change.get_style_context ();
         change_style.remove_class ("profit");
         change_style.remove_class ("loss");
+
+        var percent_change_style = this.percent_change.get_style_context ();
+        percent_change_style.remove_class ("profit");
+        percent_change_style.remove_class ("loss");
+
         if (s.regular_market_change >= 0) {
             change_style.add_class ("profit");
+            percent_change_style.add_class ("profit");
         } else {
             change_style.add_class ("loss");
+            percent_change_style.add_class ("loss");
         }
 
         var market_style = this.market.get_style_context ();


### PR DESCRIPTION
Hi owners, this is my first PR for this project, please be nice ahahaha.
I just made some changes I thought it looks better with them, please see above the differences.
I will wait for feedback. 

![Markets](https://user-images.githubusercontent.com/47716563/89029980-6fbc0600-d327-11ea-936f-24e6a02af911.png)

Visibility issues:
- [x] Make labels bold

Design Improvements:
- [x] Disengage change from percent change
Ps: Looks more cleaner this away

Thx
