### PR TITLE
Fix POTFILES

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,7 +1,9 @@
-data/com.bitstower.Markets.desktop.in
 data/com.bitstower.Markets.appdata.xml.in
+data/com.bitstower.Markets.desktop.in
 data/com.bitstower.Markets.gschema.xml
-src/window.ui
-src/main.vala
-src/window.vala
-
+data/ui/MainHeaderBar.ui
+data/ui/NewSymbolDialog.ui
+data/ui/NoSymbolsView.ui
+data/ui/PreferencesWindow.ui
+data/ui/SelectionHeaderBar.ui
+data/ui/SymbolsView.ui


### PR DESCRIPTION
The *.ui and *.vala files currently present in the POTFILES don't exist, which prevents .pot file from being created. This fixes this issue and add files from ui/ that have strings. No .vala file currently provides translation string.