### PR TITLE
Add form factors to desktop and appdata files

### DIFF
--- a/data/com.bitstower.Markets.appdata.xml.in
+++ b/data/com.bitstower.Markets.appdata.xml.in
@@ -71,4 +71,9 @@
   </releases>
 
   <content_rating type="oars-1.1" />
+
+  <custom>
+    <value key="Purism::form_factor">workstation</value>
+    <value key="Purism::form_factor">mobile</value>
+  </custom>
 </component>

--- a/data/com.bitstower.Markets.desktop.in
+++ b/data/com.bitstower.Markets.desktop.in
@@ -8,3 +8,5 @@ Icon=com.bitstower.Markets
 Categories=GTK;Office;Finance;Economy;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=stock;currency;cryptocurrency;finance;economy;
+# Translators: Do NOT translate or transliterate this text (these are enum types)!
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
This makes the app visible in the PureOS Store on the Librem 5.

See https://puri.sm/posts/specify-form-factors-in-your-librem-5-apps/