### PR TITLE
List gettext as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You'll need the following dependencies:
 * libgee
 * libhandy
 * json-glib
+* gettext
 * glib2
 * gtk3
 * meson


### PR DESCRIPTION
Without gettext, meson first issues a warnin:

```
WARNING: Gettext not found, all translation targets will be ignored.
```

but right after that, sends an error:

```
data/meson.build:4:0: ERROR: Tried to assign an invalid value to variable.
```