### PR TITLE
fix(ui): Use correct enum value for GtkLabel.valign

### DIFF
--- a/data/ui/SymbolRow.ui
+++ b/data/ui/SymbolRow.ui
@@ -66,7 +66,7 @@
                     <property name="single_line_mode">True</property>
                     <property name="ellipsize">end</property>
                     <property name="halign">start</property>
-                    <property name="valign">middle</property>
+                    <property name="valign">center</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>


### PR DESCRIPTION
Without this patch right after application startup,
but also after the Symbols are modified, the following
GTK Warnings are printed:
```
Failed to set property GtkLabel.valign to middle: Could not parse enum: 'middle'
```

It appears that the `valign` property has to to get a `GtkAlign` enum value,
where `middle` is not an option, but `center` is.