### PR TITLE
Warn when an HTTP request fails

### DIFF
--- a/src/RestClient.vala
+++ b/src/RestClient.vala
@@ -10,6 +10,10 @@ public class Markets.RestClient {
 
         yield this.queue_message (this.session, message);
 
+        if (message.status_code < 200 || message.status_code >= 300) {
+            warning (@"Unexpected response: $(message.status_code) $(message.reason_phrase)");
+        }
+
         var body = (string) message.response_body.data;
         return Json.from_string (body);
     }


### PR DESCRIPTION
This would have saved me some time in figuring out that I needed to install
glib-networking (because it's indicated in the reason_phrase that it's required,
but that wasn't being displayed anywhere).  It would also be useful to e.g. a
user who isn't seeing their stocks because their DNS is broken.
